### PR TITLE
[hotfix][actions] bump patch version by default 

### DIFF
--- a/.github/workflows/tag-version.yaml
+++ b/.github/workflows/tag-version.yaml
@@ -20,3 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
+          DEFAULT_BUMP: patch


### PR DESCRIPTION
Should only bump the patch version not minor when a PR with no description is merged
