### PR TITLE
fix: do not bump version by default

### DIFF
--- a/.github/workflows/tag-version.yaml
+++ b/.github/workflows/tag-version.yaml
@@ -20,4 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          DEFAULT_BUMP: patch
+          DEFAULT_BUMP: none


### PR DESCRIPTION
Do not bump the version by default
